### PR TITLE
Fix loading composer.json dependencies

### DIFF
--- a/system/class/Composer/Repository.php
+++ b/system/class/Composer/Repository.php
@@ -126,7 +126,10 @@ class Repository
             $this->installedPackages = [];
 
             if (is_file($installedJson = $this->getInstalledJsonPath())) {
-                foreach (Json::decode(file_get_contents($installedJson), false)->packages as $package) {
+                $packages = Json::decode(file_get_contents($installedJson), false);
+                $packages = $packages->packages ?? $packages; // composer 2.0 has wrapper
+                
+                foreach ($packages as $package) {
                     $this->installedPackages[$package->name] = $package;
                 }
             }


### PR DESCRIPTION
Composer 2.0 wraps the installed dependencies in addition to "packages", which causes problems for Composer dependencies loaded from plugins. Plugin dependencies created in Composer 1.0 then cause an error `Trying to get property 'packages' of non-object`