### PR TITLE
Add the "db.table_prefix" event

### DIFF
--- a/system/class/Database/Database.php
+++ b/system/class/Database/Database.php
@@ -346,7 +346,7 @@ class Database
      */
     static function table(string $name): string
     {
-        return self::$prefix . $name;
+        return Extend::fetch('db.table', ['name' => $name]) ?? self::$prefix . $name;
     }
 
     /**


### PR DESCRIPTION
Allows you to influence the prefix for selected tables, it could be useful for sharing tables for multiple system installations in one database. I would say it will be cleaner than duplicating content, due to the system prefix.