### PR TITLE
Fix condition, locked comments hide answers on comments

### DIFF
--- a/system/class/Post/PostService.php
+++ b/system/class/Post/PostService.php
@@ -466,7 +466,7 @@ class PostService
                     ]);
 
                     // answers
-                    if ($replies_enabled && isset($item['_answers'])) {
+                    if (isset($item['_answers'])) {
                         foreach ($item['_answers'] as $answer) {
                             $output .= self::renderPost($answer, $userQuery, [
                                 'current_url' => $url,


### PR DESCRIPTION
Locking comments on articles causes the written answers to be hidden after locking. The inability to answer is okay, but not rendering the answers is wrong.