### PR TITLE
Add page setting variables for plugin content

### DIFF
--- a/admin/action/modules/include/page-editscript-init.php
+++ b/admin/action/modules/include/page-editscript-init.php
@@ -28,6 +28,8 @@ $editscript_enable_access = true;
 $editscript_extra_row = '';
 $editscript_extra_row2 = '';
 $editscript_extra = '';
+$editscript_setting_extra = '';
+$editscript_setting_extra2 = '';
 $type_array = Page::getTypes();
 $plugin_type_array = Page::getPluginTypes();
 

--- a/admin/action/modules/include/page-editscript.php
+++ b/admin/action/modules/include/page-editscript.php
@@ -546,6 +546,7 @@ $output .= "<form class='cform' action='index.php?p=content-edit" . $type_array[
 
                     <div id='settingseditform'>"
 
+                    . $editscript_setting_extra
                     ."<fieldset>
                         <legend>" . _lang('admin.content.form.settings') . "</legend>
                         <table>
@@ -598,6 +599,7 @@ $output .= "<form class='cform' action='index.php?p=content-edit" . $type_array[
                         </tbody>
                         </table>
                     </fieldset>" : '')
+                . $editscript_setting_extra2
                 . "</div>
                 </td>
             </tr>


### PR DESCRIPTION
For example, it allows you to add a link or button to create an article with a plugin after creating them, without going to the menu. It is also applicable to other types of pages, such as galleries, etc. Or other functionality, currently it is not very easy to edit.