### PR TITLE
Fix loading translations from plugin

### DIFF
--- a/system/class/Localization/LocalizationDirectory.php
+++ b/system/class/Localization/LocalizationDirectory.php
@@ -4,6 +4,7 @@ namespace Sunlight\Localization;
 
 use Sunlight\Core;
 use Sunlight\Settings;
+use Sunlight\User;
 
 /**
  * Localization dictionary that loads entries from files in the given directory
@@ -83,7 +84,14 @@ class LocalizationDirectory extends LocalizationDictionary
      */
     private function load(): void
     {
-        if ($this->hasDictionaryForLanguage(Settings::get('language'))) {
+        if(
+            User::isLoggedIn()
+            && Settings::get('language_allowcustom')
+            && User::$data['language'] !== ''
+            && $this->hasDictionaryForLanguage(User::$data['language'])
+        ){
+            $this->add($this->loadDictionaryForLanguage(User::$data['language']));
+        } elseif ($this->hasDictionaryForLanguage(Settings::get('language'))) {
             $this->add($this->loadDictionaryForLanguage(Settings::get('language')));
         } elseif (Core::$fallbackLang !== Settings::get('language') && $this->hasDictionaryForLanguage(Core::$fallbackLang)) {
             $this->add($this->loadDictionaryForLanguage(Core::$fallbackLang));


### PR DESCRIPTION
If the user has his own language set, translations in plugins are read from the system language settings. It does not respect the language selected by the user, even if the plugin supports it.

![img](https://user-images.githubusercontent.com/1703182/136084331-5f3e38ea-4d0e-4e27-a9d6-f40f7357a395.png)
