### PR TITLE
Add render image event

### DIFF
--- a/system/class/Gallery.php
+++ b/system/class/Gallery.php
@@ -52,16 +52,28 @@ class Gallery
             $alt = basename(Url::parse($fullUrl)->getPath());
         }
 
-        return '<a'
-            . ' href="' . _e($fullUrl) . '" target="_blank"'
-            . (isset($lightboxid) ? Extend::buffer('image.lightbox', ['group' => 'gal_' . $lightboxid]) : '')
-            . (($img['title']) ? ' title="' . _e($img['title']) . '"' : '')
-            . '>'
-            . '<img'
-            . ' src="' . _e($prevUrl) . '"'
-            . ' alt="' . _e($alt) . '"'
-            . '>'
-            . "</a>\n";
+        $image = Extend::buffer('gallery.image.render', [
+            'image' => $img,
+            'full_url' => $fullUrl,
+            'full_file' => $fullFile,
+            'prev_url' => $prevUrl,
+            'alt' => $alt,
+            'lightbox_id' => $lightboxid
+        ]);
+
+        if ($image === '') {
+            $image = '<a'
+                . ' href="' . _e($fullUrl) . '" target="_blank"'
+                . (isset($lightboxid) ? Extend::buffer('image.lightbox', ['group' => 'gal_' . $lightboxid]) : '')
+                . (($img['title']) ? ' title="' . _e($img['title']) . '"' : '')
+                . '>'
+                . '<img'
+                . ' src="' . _e($prevUrl) . '"'
+                . ' alt="' . _e($alt) . '"'
+                . '>'
+                . "</a>\n";
+        }
+        return $image;
     }
 
     /**


### PR DESCRIPTION
It is currently not possible to change the output of Gallery::renderImage(). For custom template styling, it is often necessary to wrap images with various tags and CSS classes. The only option is to replace the entire gallery page script.