### PR TITLE
Fix display of restricted boxes in module

### DIFF
--- a/system/class/Page/Page.php
+++ b/system/class/Page/Page.php
@@ -214,6 +214,11 @@ abstract class Page
         // zjistit aktualni stranku
         [$currentId, $currentData] = self::getActive();
 
+        // stranka bez ID (napr. modul)
+        if ($currentId === null) {
+            return false;
+        }
+
         if ($currentData !== null) {
             $currentLevel = $currentData['node_level'];
         } else {


### PR DESCRIPTION
Boxes selected only for certain pages do not work in modules. Page::getPath() requires int as the first argument and in case the module gets null.