### PR TITLE
Admin::userSelect always contains selected user/group

### DIFF
--- a/admin/action/modules/users-edit.php
+++ b/admin/action/modules/users-edit.php
@@ -64,7 +64,7 @@ if (isset($_GET['id'])) {
 if ($continue) {
     
     // vyber skupiny
-    $group_select = Admin::userSelect('group_id', (isset($_POST['group_id']) ? (int) Request::post('group_id') : $query['group_id']), "id!=2 AND level<" . User::getLevel(), null, null, true);
+    $group_select = Admin::userSelect('group_id', (isset($_POST['group_id']) ? (int) Request::post('group_id') : $query['group_id']), "id!=" . User::GUEST_GROUP_ID . " AND level<" . User::getLevel(), null, null, true);
 
     /* ---  ulozeni  --- */
     if (isset($_POST['username'])) {
@@ -148,7 +148,7 @@ if ($continue) {
         // group
         if (isset($_POST['group_id'])) {
             $group = (int) Request::post('group_id');
-            $group_test = DB::queryRow("SELECT level FROM " . DB::table('user_group') . " WHERE id=" . $group . " AND id!=2 AND level<" . User::getLevel());
+            $group_test = DB::queryRow("SELECT level FROM " . DB::table('user_group') . " WHERE id=" . $group . " AND id!=" . User::GUEST_GROUP_ID . " AND level<" . User::getLevel());
             if ($group_test !== false) {
                 if ($group_test['level'] > User::getLevel()) {
                     $errors[] = _lang('global.badinput');

--- a/admin/action/modules/users-move.php
+++ b/admin/action/modules/users-move.php
@@ -40,6 +40,6 @@ if (isset($_POST['sourcegroup'])) {
 
 $output .= $message . "
 <form class='cform' action='" . _e(Router::admin('users-move')) . "' method='post'>
-" . _lang('admin.users.move.text1') . " " . Admin::userSelect("sourcegroup", -1, "id!=" . User::GUEST_GROUP_ID, null, null, true) . " " . _lang('admin.users.move.text2') . " " . Admin::userSelect("targetgroup", -1, "id!=2", null, null, true) . " <input class='button' type='submit' value='" . _lang('global.do') . "' onclick='return Sunlight.confirm();'>
+" . _lang('admin.users.move.text1') . " " . Admin::userSelect("sourcegroup", -1, "id!=" . User::GUEST_GROUP_ID, null, null, true) . " " . _lang('admin.users.move.text2') . " " . Admin::userSelect("targetgroup", -1, "id!=" . User::GUEST_GROUP_ID, null, null, true) . " <input class='button' type='submit' value='" . _lang('global.do') . "' onclick='return Sunlight.confirm();'>
 " . Xsrf::getInput() . "</form>
 ";

--- a/admin/class/Admin.php
+++ b/admin/class/Admin.php
@@ -329,7 +329,7 @@ abstract class Admin
             $multiple = "";
         }
         $output = "<select name='" . $name . "'" . $class . $multiple . ">";
-        $query = DB::query("SELECT id,title,level FROM " . DB::table('user_group') . " WHERE " . $gcond . " AND id!=2 ORDER BY level DESC");
+        $query = DB::query("SELECT id,title,level FROM " . DB::table('user_group') . " WHERE " . $gcond . " AND id!=" . User::GUEST_GROUP_ID . " ORDER BY level DESC");
         if ($extraoption != null) {
             $output .= "<option value='-1' class='special'>" . $extraoption . "</option>";
         }

--- a/admin/class/Admin.php
+++ b/admin/class/Admin.php
@@ -347,16 +347,16 @@ abstract class Admin
                         } else {
                             $sel = "";
                         }
-                        $output .= "<option value='" . $user['id'] . "'" . $sel . ">" . $user[($user['publicname'] !== null) ? 'publicname' : 'username'] . "</option>\n";
+                        $output .= "<option value='" . $user['id'] . "'" . $sel . ">" . ($user['publicname'] ?? $user['username']) . "</option>\n";
                     }
                     $output .= "</optgroup>";
                 }
             }
             if (!$containsSelected) {
-                $missingUser = DB::queryRow("SELECT u.id, u.username, u.publicname, g.title as grouptitle FROM " . DB::table('user') . " AS u JOIN " . DB::table('user_group') . " AS g ON(u.group_id=g.id) WHERE u.id = " . $selected);
-                if ($missingUser !== false) {
-                    $output .= "<optgroup label='" . $missingUser['grouptitle'] . "'>";
-                    $output .= "<option value='" . $missingUser['id'] . "' selected>" . $missingUser[($missingUser['publicname'] !== null) ? 'publicname' : 'username'] . "</option>\n";
+                $selectedUser = DB::queryRow("SELECT u.id, u.username, u.publicname, g.title as grouptitle FROM " . DB::table('user') . " AS u JOIN " . DB::table('user_group') . " AS g ON(u.group_id=g.id) WHERE u.id = " . $selected);
+                if ($selectedUser !== false) {
+                    $output .= "<optgroup label='" . $selectedUser['grouptitle'] . "'>";
+                    $output .= "<option value='" . $selectedUser['id'] . "' selected>" . ($selectedUser['publicname'] ?? $selectedUser['username']) . "</option>\n";
                     $output .= "</optgroup>";
                 }
             }
@@ -371,9 +371,9 @@ abstract class Admin
                 $output .= "<option value='" . $item['id'] . "'" . $sel . ">" . $item['title'] . " (" . DB::count('user', 'group_id=' . $item['id']) . ")</option>\n";
             }
             if (!$containsSelected) {
-                $missingGroup = DB::queryRow("SELECT id,title FROM " . DB::table('user_group') . " WHERE id=" . $selected);
-                if ($missingGroup !== false) {
-                    $output .= "<option value='" . $missingGroup['id'] . "' selected>" . $missingGroup['title'] . " (" . DB::count('user', 'group_id=' . $missingGroup['id']) . ")</option>\n";
+                $selectedGroup = DB::queryRow("SELECT id,title FROM " . DB::table('user_group') . " WHERE id=" . $selected);
+                if ($selectedGroup !== false) {
+                    $output .= "<option value='" . $selectedGroup['id'] . "' selected>" . $selectedGroup['title'] . " (" . DB::count('user', 'group_id=' . $selectedGroup['id']) . ")</option>\n";
                 }
             }
         }

--- a/system/action/modules/ulist.php
+++ b/system/action/modules/ulist.php
@@ -43,7 +43,7 @@ $output .= '
   <strong>' . _lang('user.list.groupfilter') . ':</strong> <select name="group_id">
   <option value="-1">' . _lang('global.all') . '</option>
   ';
-$query = DB::query("SELECT id,title FROM " . DB::table('user_group') . " WHERE id!=2 ORDER BY level DESC");
+$query = DB::query("SELECT id,title FROM " . DB::table('user_group') . " WHERE id!=" . User::GUEST_GROUP_ID . " ORDER BY level DESC");
 while ($item = DB::row($query)) {
     if ($item['id'] == $group) {
         $selected = ' selected';


### PR DESCRIPTION
It may happen that the saved user or group doesn't meet the conditions needed to be shown in select box generated by `Admin::userSelect`. This may happen for example when the author of the article doesn't have rights to create articles anymore. If you try to modify that article, you change the author which is not what you want since you still want to leave the credit to the original author. 

This PR will add the selected user or group to the list if it no longer meets the conditions.