### PR TITLE
Add an event to validate user privilege

### DIFF
--- a/system/class/User.php
+++ b/system/class/User.php
@@ -288,7 +288,9 @@ abstract class User
      */
     static function hasPrivilege(string $name): bool
     {
-        return isset(self::$privilegeMap[$name]) && self::$group[$name];
+        $hasPrivilege = isset(self::$privilegeMap[$name]) && self::$group[$name];
+        Extend::call('user.privilege.validate', ['name' => $name, 'valid' => &$hasPrivilege]);
+        return $hasPrivilege;
     }
     
     static function isSuperAdmin(): bool


### PR DESCRIPTION
In the future, it will allow you to use the plugin to validate rights, check permissions, for example, for a specific page in the system. For example, this will allow you to define moderator rights for a single forum, instead of the entire site.