### PR TITLE
Add arguments to 'mod.editpost.edit' event

### DIFF
--- a/system/action/modules/editpost.php
+++ b/system/action/modules/editpost.php
@@ -73,6 +73,8 @@ if (isset($_POST['text'])) {
             Extend::call('mod.editpost.edit', [
                 'id' => $id,
                 'post' => $post,
+                'subject' => &$subject,
+                'text' => &$text,
                 'continue' => &$continue,
             ]);
 


### PR DESCRIPTION
Event contains only the original post data (those stored in the database). The actual text/subject entered is not available in the event and it is not possible to compare, for example, whether the content has changed or the post has just been resaved without changes. I added the reference because of possible modification of the content before saving.