### PR TITLE
Fix saving of bool and null values to the database

### DIFF
--- a/system/class/Database/Database.php
+++ b/system/class/Database/Database.php
@@ -353,7 +353,7 @@ abstract class Database
         }
 
         if (is_bool($value)) {
-            $value = (int)$value;
+            return (int) $value;
         }
 
         if (is_numeric($value)) {

--- a/system/class/Database/Database.php
+++ b/system/class/Database/Database.php
@@ -352,6 +352,10 @@ abstract class Database
             return $value->getSql();
         }
 
+        if (is_bool($value)) {
+            $value = (int)$value;
+        }
+
         if (is_numeric($value)) {
             $value = (0 + $value);
 
@@ -606,7 +610,7 @@ abstract class Database
 
         foreach ($ids as $id) {
             foreach ($changesetMap[$id] as $column => $value) {
-                $commonChanges[$column][$value][$id] = true;
+                $commonChanges[$column][self::val($value)][$id] = true;
             }
         }
 
@@ -619,7 +623,7 @@ abstract class Database
 
                 foreach ($changeList as &$changeItem) {
                     if ($changeItem['set'] === $set) {
-                        $changeItem['changeset'][$column] = $value;
+                        $changeItem['changeset'][$column] = self::raw($value);
                         $merged = true;
                         break;
                     }
@@ -628,7 +632,7 @@ abstract class Database
                 if (!$merged) {
                     $changeList[] = [
                         'set' => $set,
-                        'changeset' => [$column => $value],
+                        'changeset' => [$column => self::raw($value)],
                     ];
                 }
             }

--- a/system/class/Database/Database.php
+++ b/system/class/Database/Database.php
@@ -353,7 +353,7 @@ abstract class Database
         }
 
         if (is_bool($value)) {
-            return (int) $value;
+            return $value ? '1' : '0';
         }
 
         if (is_numeric($value)) {


### PR DESCRIPTION
The `Database::val` method did not work correctly with bool values. They were interpreted as strings "1" and "" which is not valid for database. It is now converted to integer instead of string.

The `Database::changesetMapToList` method did not work properly with null values as they were converted to an empty string when used as key in an associative array. It now uses the `Database::val` and `Database::raw` methods to avoid this problem.