### PR TITLE
Add user.ready extend event

### DIFF
--- a/system/class/User.php
+++ b/system/class/User.php
@@ -277,6 +277,9 @@ abstract class User
             // set variables
             self::$data = $userData;
             self::$group = $groupData;
+
+            // event
+            Extend::call('user.ready');
         } else {
             // guest
             $groupData = DB::queryRow('SELECT * FROM ' . DB::table('user_group') . ' WHERE id=' . self::GUEST_GROUP_ID);


### PR DESCRIPTION
The event allows to register extend plugins after user login and use methods of the `User` class instead of manually processing arguments of the `user.auth.success` event.