### PR TITLE
Improve listing of supported keys in docblock

### DIFF
--- a/admin/class/Admin.php
+++ b/admin/class/Admin.php
@@ -118,12 +118,12 @@ abstract class Admin
      *
      * Supported options:
      * ------------------
-     * mode ('default')     'default' / 'code' (non-wysiwyg code editor) / 'lite' (short content editor)
-     * format ('html')      'xml' / 'css' / 'js' / 'json' / 'php' / 'php-raw' / 'html'
-     * cols (94)            number of textarea columns
-     * rows (25)            number of textarea rows
-     * wrap (-)             textarea wrap attribute
-     * class ('areabig')    textarea class attribute
+     * - mode ('default')     'default' / 'code' (non-wysiwyg code editor) / 'lite' (short content editor)
+     * - format ('html')      'xml' / 'css' / 'js' / 'json' / 'php' / 'php-raw' / 'html'
+     * - cols (94)            number of textarea columns
+     * - rows (25)            number of textarea rows
+     * - wrap (-)             textarea wrap attribute
+     * - class ('areabig')    textarea class attribute
      *
      * @param string $context descriptive identifier of where the editor is used (for plugins)
      * @param string $name form element name
@@ -313,16 +313,16 @@ abstract class Admin
      *
      * Supported options:
      * ------------------
-     * selected (-1)            ID of active page (or an array if multiple = TRUE)
-     * multiple (0)             allow choice of multiple pages 1/0
-     * empty_item (-)           label of empty item (ID = -1)
-     * type (-)                 limit to a single page type
-     * check_access (1)         check access to each page 1/0
-     * check_privilege (0)      also check privilege to manage each page type 1/0 (requires check_access = 1)
-     * allow_separators (0)     make separators selectable 1/0
-     * disabled_branches ([])   array of page IDs whose branches should be excluded
-     * maxlength (22)           max. length of page title or null (unlimited)
-     * attrs (-)                extra HTML with <select> attributes (without space)
+     * - selected (-1)            ID of active page (or an array if multiple = TRUE)
+     * - multiple (0)             allow choice of multiple pages 1/0
+     * - empty_item (-)           label of empty item (ID = -1)
+     * - type (-)                 limit to a single page type
+     * - check_access (1)         check access to each page 1/0
+     * - check_privilege (0)      also check privilege to manage each page type 1/0 (requires check_access = 1)
+     * - allow_separators (0)     make separators selectable 1/0
+     * - disabled_branches ([])   array of page IDs whose branches should be excluded
+     * - maxlength (22)           max. length of page title or null (unlimited)
+     * - attrs (-)                extra HTML with <select> attributes (without space)
      *
      * @param array{
      *     selected?: int|int[],
@@ -429,13 +429,13 @@ abstract class Admin
      *
      * Supported options:
      * ------------------
-     * selected (-)         ID or IDs of selected items
-     * group_cond ('1')     SQL condition for groups
-     * user_cond ('1')      SQL condition for users
-     * class (-)            CSS class on the select element
-     * extra_option (-)     add an extra option with this label (value = -1)
-     * select_groups (0)    select groups instead of users 1/0
-     * multiple (-)         render multi-select with this size
+     * - selected (-)         ID or IDs of selected items
+     * - group_cond ('1')     SQL condition for groups
+     * - user_cond ('1')      SQL condition for users
+     * - class (-)            CSS class on the select element
+     * - extra_option (-)     add an extra option with this label (value = -1)
+     * - select_groups (0)    select groups instead of users 1/0
+     * - multiple (-)         render multi-select with this size
      *
      * @param array{
      *     selected?: int|int[]|null,

--- a/admin/class/PageLister.php
+++ b/admin/class/PageLister.php
@@ -150,13 +150,13 @@ abstract class PageLister
      *
      * Supported options:
      * ------------------
-     * mode                 render mode (defaults to session value)
-     * actions (1)          render actions 1/0
-     * links (1)            page links 1/0
-     * sortable (0)         render as sortable 1/0
-     * title_editable (0)   render title as an editable input 1/0
-     * level_class (-)      render level class 1/0 or null (auto)
-     * breadcrumbs (1)      render breadcrumbs 1/0
+     * - mode                 render mode (defaults to session value)
+     * - actions (1)          render actions 1/0
+     * - links (1)            page links 1/0
+     * - sortable (0)         render as sortable 1/0
+     * - title_editable (0)   render title as an editable input 1/0
+     * - level_class (-)      render level class 1/0 or null (auto)
+     * - breadcrumbs (1)      render breadcrumbs 1/0
      *
      * @param array{
      *     mode?: int,

--- a/system/class/Core.php
+++ b/system/class/Core.php
@@ -88,12 +88,12 @@ abstract class Core
      *
      * Supported options:
      * ------------------
-     * config_file (-)          path to the configuration file, null (= default) or false (= skip)
-     * minimal_mode (0)         stop after initializing base components and environment (= no plugins, db, settings, session, etc.) 1/0
-     * session_enabled (1)      initialize session 1/0
-     * session_regenerate (0)   force new session ID 1/0
-     * content_type (-)         content type, FALSE = disabled (default is "text/html; charset=UTF-8")
-     * env ("script")           environment identifier, see Core::ENV_* constants
+     * - config_file (-)          path to the configuration file, null (= default) or false (= skip)
+     * - minimal_mode (0)         stop after initializing base components and environment (= no plugins, db, settings, session, etc.) 1/0
+     * - session_enabled (1)      initialize session 1/0
+     * - session_regenerate (0)   force new session ID 1/0
+     * - content_type (-)         content type, FALSE = disabled (default is "text/html; charset=UTF-8")
+     * - env ("script")           environment identifier, see Core::ENV_* constants
      *
      * @param string $root relative path to the system root directory (with a trailing slash)
      * @param array{

--- a/system/class/GenericTemplates.php
+++ b/system/class/GenericTemplates.php
@@ -77,15 +77,15 @@ HTML;
      *
      * Parameters supported in $assets:
      * --------------------------------
-     * meta             HTML inserted at the beginning
-     * css              array with paths to CSS files
-     * js               array with paths to JS files
-     * css_before       HTML inserted before <link> tags
-     * css_after        HTML inserted after <link> tags
-     * js_before        HTML inserted before <script> tags
-     * js_after         HTML inserted after <script> tags
-     * extend_event     extend event name
-     * favicon          true = link to favicon, false = no favicon, null = no output
+     * - meta             HTML inserted at the beginning
+     * - css              array with paths to CSS files
+     * - js               array with paths to JS files
+     * - css_before       HTML inserted before <link> tags
+     * - css_after        HTML inserted after <link> tags
+     * - js_before        HTML inserted before <script> tags
+     * - js_after         HTML inserted after <script> tags
+     * - extend_event     extend event name
+     * - favicon          true = link to favicon, false = no favicon, null = no output
      *
      * @param array{
      *     meta?: string,
@@ -194,9 +194,9 @@ HTML;
      *
      * Supported options:
      * ------------------
-     * lcfirst (1)      lowercase first letter of each message
-     * escape (1)       escape HTML in messages
-     * show_keys (0)    render array keys
+     * - lcfirst (1)      lowercase first letter of each message
+     * - escape (1)       escape HTML in messages
+     * - show_keys (0)    render array keys
      *
      * @param string[] $messages
      * @param array{lcfirst?: bool|null, escape?: bool|null, show_keys?: bool|null} $options see description

--- a/system/class/Image/ImageLoader.php
+++ b/system/class/Image/ImageLoader.php
@@ -21,9 +21,9 @@ final class ImageLoader
      *
      * Supported limits:
      * -----------------
-     * filesize (null)      max file size in bytes
-     * dimensions (null)    max image dimensions as array{w: int, h: int}
-     * memory (0.75)        max percentage of remaining memory used
+     * - filesize (null)      max file size in bytes
+     * - dimensions (null)    max image dimensions as array{w: int, h: int}
+     * - memory (0.75)        max percentage of remaining memory used
      *
      * @param array{
      *     filesize?: int|null,

--- a/system/class/Image/ImageService.php
+++ b/system/class/Image/ImageService.php
@@ -115,10 +115,10 @@ final class ImageService
      *
      * Supported options:
      * ------------------
-     * limits       {@see ImageLoader::load()}
-     * resize       {@see ImageTransformer::resize()}
-     * write        {@see Image::write()}
-     * format       source image format (otherwise determined from $source)
+     * - limits       {@see ImageLoader::load()}
+     * - resize       {@see ImageTransformer::resize()}
+     * - write        {@see Image::write()}
+     * - format       source image format (otherwise determined from $source)
      *
      * @param string $type descriptive type (for extend event)
      * @param string $source source path

--- a/system/class/Image/ImageTransformer.php
+++ b/system/class/Image/ImageTransformer.php
@@ -39,15 +39,15 @@ final class ImageTransformer
      *
      * Supported $options:
      * ------------------
-     * w                    target width (optional if "h" is specified)
-     * h                    target height (optional if "w" is specified)
-     * mode (fill)          resize mode (see RESIZE_* class constants)
-     * keep_smaller (false) don't enlarge smaller images
-     * bgcolor (null)       static bg color as array{r, g, b} (ignored if trans = TRUE)
-     * pad (false)          keep extra space instead of cropping (only in "fit" modes)
-     * align-x (0)          horizontal alignment for cropping and padding, see ALIGN_* class constants
-     * align-y (0)          vertical alignment for cropping and padding, see ALIGN_* class constants
-     * trans (false)        enable transparency
+     * - w                    target width (optional if "h" is specified)
+     * - h                    target height (optional if "w" is specified)
+     * - mode (fill)          resize mode (see RESIZE_* class constants)
+     * - keep_smaller (false) don't enlarge smaller images
+     * - bgcolor (null)       static bg color as array{r, g, b} (ignored if trans = TRUE)
+     * - pad (false)          keep extra space instead of cropping (only in "fit" modes)
+     * - align-x (0)          horizontal alignment for cropping and padding, see ALIGN_* class constants
+     * - align-y (0)          vertical alignment for cropping and padding, see ALIGN_* class constants
+     * - trans (false)        enable transparency
      *
      * @param array{
      *     w?: int|null,

--- a/system/class/Message.php
+++ b/system/class/Message.php
@@ -82,9 +82,9 @@ class Message
      *
      * Supported options:
      * ------------------
-     * type (warn)  see Message class constants
-     * text         content at the beginning of the message
-     * list         options for {@see GenericTemplates::renderMessageList()}
+     * - type (warn)  see Message class constants
+     * - text         content at the beginning of the message
+     * - list         options for {@see GenericTemplates::renderMessageList()}
      *
      * @param string[] $messages
      * @param array{

--- a/system/class/Page/PageTreeFilter.php
+++ b/system/class/Page/PageTreeFilter.php
@@ -17,11 +17,11 @@ class PageTreeFilter implements TreeFilterInterface
     /**
      * Supported options:
      * ------------------
-     * ord_start (-)    order from
-     * ord_end (-)      order to
-     * ord_level (0)    level at which to match the order (0 = root)
-     * check_level (1)  check user and page level 1/0
-     * check_public (1) check page's public column 1/0
+     * - ord_start (-)    order from
+     * - ord_end (-)      order to
+     * - ord_level (0)    level at which to match the order (0 = root)
+     * - check_level (1)  check user and page level 1/0
+     * - check_public (1) check page's public column 1/0
      *
      * @param array{
      *     ord_start?: int|null,

--- a/system/class/Paginator.php
+++ b/system/class/Paginator.php
@@ -12,9 +12,9 @@ class Paginator
      *
      * Supported options:
      * ------------------
-     * param ('page')       query parameter name
-     * link_suffix ('')     string to append after every link
-     * auto_last (0)        default to the last page 1/0
+     * - param ('page')       query parameter name
+     * - link_suffix ('')     string to append after every link
+     * - auto_last (0)        default to the last page 1/0
      *
      * @param string $url base URL to add page parameter to
      * @param int $limit max item per page
@@ -182,8 +182,8 @@ class Paginator
      * Additional supported options:
      * @see Paginator::paginate() for more options
      * -------------------------------------------
-     * cond ('1')       row filter
-     * alias (-)        table alias to use
+     * - cond ('1')       row filter
+     * - alias (-)        table alias to use
      *
      * @param string $url base URL to add page parameter to
      * @param int $limit max item per page

--- a/system/class/Plugin/Action/PluginAction.php
+++ b/system/class/Plugin/Action/PluginAction.php
@@ -82,9 +82,9 @@ abstract class PluginAction extends Action
      *
      * Supported options:
      * ------------------
-     * button_text      customize button text
-     * content_before   HTML before text
-     * content_after    HTML after text
+     * - button_text      customize button text
+     * - content_before   HTML before text
+     * - content_after    HTML after text
      *
      * @param array{
      *     button_text?: string|null,

--- a/system/class/Post/PostService.php
+++ b/system/class/Post/PostService.php
@@ -639,13 +639,13 @@ class PostService
      *
      * $vars structure:
      * ----------------
-     * url          return URL
-     * posttype     post type (see Post::* constants)
-     * posttarget   id_home
-     * xhome        id_xhome
-     * subject      show subject field 1/0
-     * is_topic     the new post is a forum topic 1/0
-     * pluginflag   plugin flag (only for posttype == Comment::PLUGIN)
+     * - url          return URL
+     * - posttype     post type (see Post::* constants)
+     * - posttarget   id_home
+     * - xhome        id_xhome
+     * - subject      show subject field 1/0
+     * - is_topic     the new post is a forum topic 1/0
+     * - pluginflag   plugin flag (only for posttype == Comment::PLUGIN)
      *
      * @param array{
      *     url: string,

--- a/system/class/Router.php
+++ b/system/class/Router.php
@@ -11,9 +11,9 @@ use Sunlight\Util\Html;
 /**
  * Supported options:
  * ------------------
- * absolute (false)     generate an absolute URL 1/0
- * query (null)         array of query parameters
- * fragment (null)      fragment string (without #)
+ * - absolute (false)     generate an absolute URL 1/0
+ * - query (null)         array of query parameters
+ * - fragment (null)      fragment string (without #)
  *
  * @psalm-type RouterOptions = array{
  *     absolute?: bool|null,
@@ -210,17 +210,17 @@ abstract class Router
      *
      * Supported options
      * -----------------
-     * plain (0)        return only plain username 1/0
-     * link (1)         link to user profile 1/0
-     * custom_link (-)  custom URL to use instead of user's profile
-     * color (1)        add color based on user group 1/0
-     * icon (1)         show group icon 1/0
-     * publicname (1)   use public name, if available 1/0
-     * new_window (0)   link to a new window 1/0 (defaults to 1 in admin env)
-     * max_len (-)      max. username length
-     * class (-)        custom CSS class
-     * title (-)        title
-     * url (-)          URL options (see class description)
+     * - plain (0)        return only plain username 1/0
+     * - link (1)         link to user profile 1/0
+     * - custom_link (-)  custom URL to use instead of user's profile
+     * - color (1)        add color based on user group 1/0
+     * - icon (1)         show group icon 1/0
+     * - publicname (1)   use public name, if available 1/0
+     * - new_window (0)   link to a new window 1/0 (defaults to 1 in admin env)
+     * - max_len (-)      max. username length
+     * - class (-)        custom CSS class
+     * - title (-)        title
+     * - url (-)          URL options (see class description)
      *
      * @param array $data user data {@see User::createQuery()}
      * @param array{

--- a/system/class/Template.php
+++ b/system/class/Template.php
@@ -222,9 +222,9 @@ abstract class Template
      *
      * Supported options:
      * ------------------
-     * cms (1)      show link to CMS website
-     * admin (-)    show link to administration
-     *              (TRUE - always, FALSE - never, NULL - if user has privileges)
+     * - cms (1)      show link to CMS website
+     * - admin (-)    show link to administration
+     *                (TRUE - always, FALSE - never, NULL - if user has privileges)
      *
      * @param array{cms?: bool, admin?: bool|null} $options see description
      */
@@ -303,15 +303,15 @@ abstract class Template
      *
      * Supported options:
      * ------------------
-     * page_id (-)                      ID of page to render menu for (-1 = current)
-     * children_only (1)                only list children (requires page_id)
-     * max_depth (-)                    maximum number of levels (null = unlimited)
-     * ord_start (-)                    only list pages with this order number or higher
-     * ord_end (-)                      only list pages with this order number or less
-     * css_class (-)                    CSS class for the container tag
-     * extend_event ("tpl.menu.item")   menu item extend event name or null
-     * type ("tree")                    menu type identifier (for events)
-     * filter (-)                       additional options for {@see PageTreeFilter}
+     * - page_id (-)                      ID of page to render menu for (-1 = current)
+     * - children_only (1)                only list children (requires page_id)
+     * - max_depth (-)                    maximum number of levels (null = unlimited)
+     * - ord_start (-)                    only list pages with this order number or higher
+     * - ord_end (-)                      only list pages with this order number or less
+     * - css_class (-)                    CSS class for the container tag
+     * - extend_event ("tpl.menu.item")   menu item extend event name or null
+     * - type ("tree")                    menu type identifier (for events)
+     * - filter (-)                       additional options for {@see PageTreeFilter}
      *
      * @param array{
      *     page_id?: int|null,

--- a/system/class/User.php
+++ b/system/class/User.php
@@ -1067,12 +1067,12 @@ abstract class User
      *
      * Supported options:
      * ------------------
-     * get_path (0)     return avatar path instead of HTML 1/0
-     * default (1)      use default avatar if user has none, otherwise return NULL 1/0
-     * default_dark (-) use dark variant of the default avatar 1/0 (default depends on current template)
-     * link (1)         link to the user's profile 1/0
-     * extend (1)       enable extend event 1/0
-     * class (-)        custom CSS class
+     * - get_path (0)     return avatar path instead of HTML 1/0
+     * - default (1)      use default avatar if user has none, otherwise return NULL 1/0
+     * - default_dark (-) use dark variant of the default avatar 1/0 (default depends on current template)
+     * - link (1)         link to the user's profile 1/0
+     * - extend (1)       enable extend event 1/0
+     * - class (-)        custom CSS class
      *
      * @param array $data user data (avatar, username, publicname)
      * @param array{

--- a/system/class/Util/Filesystem.php
+++ b/system/class/Util/Filesystem.php
@@ -276,9 +276,9 @@ abstract class Filesystem
      *
      * Supported options:
      * ------------------
-     * keep_dir (0)         keep the empty directory (remove children only) 1/0
-     * files_only (0)       remove files only (keep directory structure) 1/0
-     * file_callback (-)    callback(\SplFileInfo file): bool - decide, whether to remove a file or not
+     * - keep_dir (0)         keep the empty directory (remove children only) 1/0
+     * - files_only (0)       remove files only (keep directory structure) 1/0
+     * - file_callback (-)    callback(\SplFileInfo file): bool - decide, whether to remove a file or not
      *                      (this option is active only if files_only = 1)
      *
      * @param string $path path to the directory

--- a/system/class/Util/Form.php
+++ b/system/class/Util/Form.php
@@ -230,9 +230,9 @@ abstract class Form
      *
      * Supported options:
      * ------------------
-     * input_class (-)          input class name
-     * now_toggle (0)           add an option to set the timestamp to current time on save 1/0
-     * now_toggle_default (0)   enable the now_toggle by default 1/0
+     * - input_class (-)          input class name
+     * - now_toggle (0)           add an option to set the timestamp to current time on save 1/0
+     * - now_toggle_default (0)   enable the now_toggle by default 1/0
      *
      * @param string $name input name
      * @param int|null $timestamp pre-filled timestamp
@@ -311,27 +311,27 @@ abstract class Form
      *
      * Supported options:
      * ------------------
-     * name (-)             name attribute
-     * method (post)        method attribute
-     * action (-)           action attribute
-     * autocomplete (-)     autocomplete attribute
-     * enctype (-)          enctype attribute
-     * multipart (0)        set enctype to "multipart/form-data"
-     * id (-)               id attribute
-     * class (-)            class attribute
-     * embedded (0)         don't render <form> tag and XSRF input
-     * table_attrs          custom HTML at the end of the <table> tag
-     * table_prepend        custom after before <table>
-     * table_append         custom HTML before </table>
-     * form_prepend         custom HTML after <form>
-     * form_append          custom HTML before </form>
+     * - name (-)             name attribute
+     * - method (post)        method attribute
+     * - action (-)           action attribute
+     * - autocomplete (-)     autocomplete attribute
+     * - enctype (-)          enctype attribute
+     * - multipart (0)        set enctype to "multipart/form-data"
+     * - id (-)               id attribute
+     * - class (-)            class attribute
+     * - embedded (0)         don't render <form> tag and XSRF input
+     * - table_attrs          custom HTML at the end of the <table> tag
+     * - table_prepend        custom after before <table>
+     * - table_append         custom HTML before </table>
+     * - form_prepend         custom HTML after <form>
+     * - form_append          custom HTML before </form>
      *
      * Format of a single row in $rows:
      * --------------------------------
-     * label (-)        row label
-     * content (-)      row content
-     * top (0)          align the row to the top 1/0
-     * class (-)        custom <tr> class
+     * - label (-)        row label
+     * - content (-)      row content
+     * - top (0)          align the row to the top 1/0
+     * - class (-)        custom <tr> class
      *
      * - if both label and content is empty, the row is skipped
      * - if label is null, the content cell will span the entire row
@@ -444,10 +444,10 @@ abstract class Form
      *
      * Supported options:
      * ------------------
-     * label ('')   row label
-     * name (-)     submit button name
-     * text         submit button text
-     * append       HTML after submit button
+     * - label ('')   row label
+     * - name (-)     submit button name
+     * - text         submit button text
+     * - append       HTML after submit button
      *
      * @param array{
      *     label?: string|null,

--- a/system/class/Util/HttpClient.php
+++ b/system/class/Util/HttpClient.php
@@ -11,9 +11,9 @@ use Sunlight\Core;
  *
  * Supported options:
  * ------------------
- * timeout      request timeout in seconds (float, default = 60, null/<=0 means unlimited)
- * headers      numerically indexed list of additional header strings
- * user_agent   user agent string
+ * - timeout      request timeout in seconds (float, default = 60, null/<=0 means unlimited)
+ * - headers      numerically indexed list of additional header strings
+ * - user_agent   user agent string
  *
  * @psalm-type HttpClientOptions = array{timeout?: float|null, headers?: list<string>, user_agent?: string}
  */

--- a/system/class/Util/StringHelper.php
+++ b/system/class/Util/StringHelper.php
@@ -59,10 +59,10 @@ abstract class StringHelper
      *
      * Supported options:
      * ------------------
-     * lower (1)        generate lowercase slug 1/0
-     * extra ("._")     string list of extra allowed characters
-     * max_len (255)    slug length limit or null
-     * fallback ("")    fallback slug in case the process fails
+     * - lower (1)        generate lowercase slug 1/0
+     * - extra ("._")     string list of extra allowed characters
+     * - max_len (255)    slug length limit or null
+     * - fallback ("")    fallback slug in case the process fails
      *
      * @param array{lower?: bool, extra?: string, max_len?: int|null, fallback?: string} $options see description
      */

--- a/system/class/Util/Zip.php
+++ b/system/class/Util/Zip.php
@@ -92,12 +92,12 @@ abstract class Zip
      *
      * Supported options:
      * ------------------
-     * path_mode (PATH_FULL)    (see Zip::PATH_* constants)
-     * dir_mode (0777)          mode of newly created directories
-     * recursive (1)            extract subdirectories 1/0
-     * exclude_prefix (-)       a common prefix to exclude from subpaths (e.g. "foo/")
+     * - path_mode (PATH_FULL)    (see Zip::PATH_* constants)
+     * - dir_mode (0777)          mode of newly created directories
+     * - recursive (1)            extract subdirectories 1/0
+     * - exclude_prefix (-)       a common prefix to exclude from subpaths (e.g. "foo/")
      *                          (the trailing slash is important)
-     * big_file_threshold (-)
+     * - big_file_threshold (-)
      *
      * @param string[]|string $directories archive directory paths (e.g. "foo", "foo/bar" or "" for root)
      * @param string $targetPath path where to extract the files to


### PR DESCRIPTION
Minor improvements to the listed configuration options, renders more clearly with bullets.

![image](https://github.com/sunlight-cms/sunlight-cms/assets/1703182/348bc074-8011-4572-8993-3b8cb7f9aa16)
